### PR TITLE
fix tests and `createToken` to satisfy the `ITokenPayload` interface

### DIFF
--- a/plugins/auth-jwt/static/auth/base/token.service.base.ts
+++ b/plugins/auth-jwt/static/auth/base/token.service.base.ts
@@ -1,8 +1,7 @@
-/* eslint-disable import/no-unresolved */
 import { Injectable } from "@nestjs/common";
 import { JwtService } from "@nestjs/jwt";
 import { INVALID_PASSWORD_ERROR, INVALID_USERNAME_ERROR } from "../constants";
-import { ITokenService } from "../ITokenService";
+import { ITokenPayload, ITokenService } from "../ITokenService";
 /**
  * TokenServiceBase is a jwt bearer implementation of ITokenService
  */
@@ -11,13 +10,14 @@ export class TokenServiceBase implements ITokenService {
   constructor(protected readonly jwtService: JwtService) {}
   /**
    *
+   * @param id
    * @param username
    * @param password
-   * @returns a jwt token sign with the username
+   * @returns a jwt token sign with the username and the user id
    */
-  createToken(username: string, password: string): Promise<string> {
+  createToken({ id, password, username }: ITokenPayload): Promise<string> {
     if (!username) return Promise.reject(INVALID_USERNAME_ERROR);
     if (!password) return Promise.reject(INVALID_PASSWORD_ERROR);
-    return this.jwtService.signAsync({ username });
+    return this.jwtService.signAsync({ sub: id, username });
   }
 }

--- a/plugins/auth-jwt/static/auth/jwt/jwt.strategy.ts
+++ b/plugins/auth-jwt/static/auth/jwt/jwt.strategy.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable } from "@nestjs/common";
 import { JWT_SECRET_KEY } from "../../constants";
 import { UserService } from "../../user/user.service";
 import { JwtStrategyBase } from "./base/jwt.strategy.base";
+
 @Injectable()
 export class JwtStrategy extends JwtStrategyBase {
   constructor(

--- a/plugins/auth-jwt/static/tests/auth/jwt/jwt.strategy.spec.ts
+++ b/plugins/auth-jwt/static/tests/auth/jwt/jwt.strategy.spec.ts
@@ -1,8 +1,6 @@
 import { UnauthorizedException } from "@nestjs/common";
 import { mock } from "jest-mock-extended";
 import { JwtStrategyBase } from "../../../auth/jwt/base/jwt.strategy.base";
-// @ts-ignore
-// eslint-disable-next-line
 import { UserService } from "../../../user/user.service";
 import { TEST_USER } from "../constants";
 
@@ -19,6 +17,7 @@ describe("Testing the jwtStrategyBase.validate()", () => {
       .mockReturnValue(Promise.resolve(null));
     //ACT
     const result = jwtStrategy.validate({
+      id: TEST_USER.id,
       username: TEST_USER.username,
       roles: TEST_USER.roles,
     });

--- a/plugins/auth-jwt/static/tests/auth/token.service.spec.ts
+++ b/plugins/auth-jwt/static/tests/auth/token.service.spec.ts
@@ -1,14 +1,10 @@
-/* eslint-disable import/no-unresolved */
 import { JwtService } from "@nestjs/jwt";
 import { mock } from "jest-mock-extended";
-//@ts-ignore
 import { TokenServiceBase } from "../../auth/base/token.service.base";
 import {
   INVALID_PASSWORD_ERROR,
   INVALID_USERNAME_ERROR,
-  //@ts-ignore
 } from "../../auth/constants";
-//@ts-ignore
 import { SIGN_TOKEN, VALID_CREDENTIALS } from "./constants";
 
 describe("Testing the TokenServiceBase", () => {
@@ -22,26 +18,27 @@ describe("Testing the TokenServiceBase", () => {
     it("should create valid token for valid username and password", async () => {
       jwtService.signAsync.mockReturnValue(Promise.resolve(SIGN_TOKEN));
       expect(
-        await tokenServiceBase.createToken(
-          VALID_CREDENTIALS.username,
-          VALID_CREDENTIALS.password
-        )
+        await tokenServiceBase.createToken({
+          id: VALID_CREDENTIALS.id,
+          username: VALID_CREDENTIALS.username,
+          password: VALID_CREDENTIALS.password,
+        })
       ).toBe(SIGN_TOKEN);
     });
     it("should reject when username missing", () => {
-      const result = tokenServiceBase.createToken(
-        //@ts-ignore
-        null,
-        VALID_CREDENTIALS.password
-      );
+      const result = tokenServiceBase.createToken({
+        id: VALID_CREDENTIALS.id,
+        username: null,
+        password: VALID_CREDENTIALS.password,
+      });
       return expect(result).rejects.toBe(INVALID_USERNAME_ERROR);
     });
     it("should reject when password missing", () => {
-      const result = tokenServiceBase.createToken(
-        VALID_CREDENTIALS.username,
-        //@ts-ignore
-        null
-      );
+      const result = tokenServiceBase.createToken({
+        id: VALID_CREDENTIALS.id,
+        username: VALID_CREDENTIALS.username,
+        password: null,
+      });
       return expect(result).rejects.toBe(INVALID_PASSWORD_ERROR);
     });
   });


### PR DESCRIPTION
resolved the plugin part of: https://github.com/amplication/amplication/issues/3947

The following error occurred when I added the`JWT` plugin to the `installedPlugins` mock

```
import { PluginInstallation } from "@amplication/code-gen-types";

export const installedPlugins: PluginInstallation[] = [
  {
    id: "auth-jwt",
    pluginId: "auth-jwt",
    npm: "@amplication/plugin-auth-jwt",
    enabled: true,
  },
];
```

![image](https://user-images.githubusercontent.com/39680385/192024957-3222a1d1-bfb4-45e8-9066-c848438610b3.png)

This is NOT happening with the `basic` strategy
