### PR TITLE
feat(publish-workflow): add automation for publishing npm packages

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,5 @@
-name: Publish a package to NPM registry
+name: npm publish
+run-name: publish ${{ inputs.plugin }} by @${{ github.actor }}
 
 on:
   workflow_dispatch:
@@ -27,8 +28,8 @@ on:
         default: false
 
 jobs:
-  build-and-publish:
-    if: ${{ github.event.inputs.publish }} == true
+  publish:
+    if: ${{ github.event.inputs.publish }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -44,8 +45,18 @@ jobs:
         run: npm ci && npm run build
         working-directory: plugins/${{ github.event.inputs.plugin }}
 
-      - name: Publish package on NPM 📦
+      # if the branch is the default branch, the latest tag is applied
+      - name: Publish package on NPM [latest] 📦
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: npm publish
+        working-directory: plugins/${{ github.event.inputs.plugin }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # if the branch is not the default branch, the beta tag is applied
+      - name: Publish package on NPM [beta] 📦
+        if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
+        run: npm publish --tag beta
         working-directory: plugins/${{ github.event.inputs.plugin }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,9 +12,11 @@ on:
           - "auth-core"
           - "auth-jwt"
           - "broker-kafka"
+          - "ci-github-actions"
           - "db-mongo"
           - "db-mysql"
           - "db-postgres"
+          - "deployment-helm-chart"
           - "formatter-prettier"
           - "nestjs-nats"
           - "swagger-apibody"
@@ -26,6 +28,7 @@ on:
 
 jobs:
   build-and-publish:
+    if: ${{ github.event.inputs.publish }} == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -39,8 +42,10 @@ jobs:
 
       - name: Install dependencies and build 🔧
         run: npm ci && npm run build
+        working-directory: plugins/${{ github.event.inputs.plugin }}
 
       - name: Publish package on NPM 📦
         run: npm publish
+        working-directory: plugins/${{ github.event.inputs.plugin }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,46 @@
+name: Publish a package to NPM registry
+
+on:
+  workflow_dispatch:
+    inputs:
+      plugin:
+        description: "Plugin to be published"
+        type: choice
+        required: true
+        options:
+          - "auth-basic"
+          - "auth-core"
+          - "auth-jwt"
+          - "broker-kafka"
+          - "db-mongo"
+          - "db-mysql"
+          - "db-postgres"
+          - "formatter-prettier"
+          - "nestjs-nats"
+          - "swagger-apibody"
+      publish:
+        description: "Publish package"
+        type: boolean
+        required: true
+        default: false
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies and build 🔧
+        run: npm ci && npm run build
+
+      - name: Publish package on NPM 📦
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@ For more information, read [Using Plugins](https://docs.amplication.com/docs/get
 ## Developing Plugins
 
 You will soon be able to develop your plugins to implement standards, best practices, and custom integrations, and to do almost anything you want with the generated code.
+
+## Publishing Plugins
+
+An github actions worflow has been added to publish a plugin the npm registry. It lets you specify a pre-determined list of plugin names (additional plugins will have to be added to this list).
+
+- `latest` tag: when using the default branch for this repository when triggering the workflow, the package will be tagged with latest.
+
+- `beta` tag: when using a non-default branch, e.g., a branch for development for running the workflow the package is release with the beta tag.

--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ An github actions worflow has been added to publish a plugin the npm registry. I
 
 - `latest` tag: when using the default branch for this repository when triggering the workflow, the package will be tagged with latest.
 
-- `beta` tag: when using a non-default branch, e.g., a branch for development when triggering the workflow, the package will be tagged with beta.
+- `beta` tag: when using a non-default branch, e.g., a branch for development, when triggering the workflow the package will be tagged with beta.

--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ An github actions worflow has been added to publish a plugin the npm registry. I
 
 - `latest` tag: when using the default branch for this repository when triggering the workflow, the package will be tagged with latest.
 
-- `beta` tag: when using a non-default branch, e.g., a branch for development for running the workflow the package is release with the beta tag.
+- `beta` tag: when using a non-default branch, e.g., a branch for development when triggering the workflow, the package will be tagged with beta.


### PR DESCRIPTION
Publishing the plugins is currently done manually, this workflow makes that manual step somewhat more automated. Requiring only selection of the plugin and whether to publish the package or not.