### PR TITLE
fix(publish): also pass the access configuration of the package in the publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -48,7 +48,7 @@ jobs:
       # if the branch is the default branch, the latest tag is applied
       - name: Publish package on NPM [latest] 📦
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        run: npm publish
+        run: npm publish --access public
         working-directory: plugins/${{ github.event.inputs.plugin }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -56,7 +56,7 @@ jobs:
       # if the branch is not the default branch, the beta tag is applied
       - name: Publish package on NPM [beta] 📦
         if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
-        run: npm publish --tag beta
+        run: npm publish --access public --tag beta
         working-directory: plugins/${{ github.event.inputs.plugin }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
If the package wasnt published already the workflow will error because by default it will try and publish a new package as private.