### PR TITLE
feat(deployment-helm-chart): add init-container for prisma migration on start-up

### DIFF
--- a/plugins/deployment-helm-chart/package-lock.json
+++ b/plugins/deployment-helm-chart/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amplication/plugin-deployment-helm-chart",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@amplication/plugin-deployment-helm-chart",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@amplication/code-gen-types": "^2.0.1",

--- a/plugins/deployment-helm-chart/package.json
+++ b/plugins/deployment-helm-chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/plugin-deployment-helm-chart",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Add helm chart for deployment of the service",
   "main": "dist/index.js",
   "scripts": {

--- a/plugins/deployment-helm-chart/src/static/chart/templates/deployment.yaml
+++ b/plugins/deployment-helm-chart/src/static/chart/templates/deployment.yaml
@@ -30,6 +30,21 @@ spec:
       serviceAccountName: {{ include "${{ SERVICE_NAME }}.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if or .Values.variables.configmap.DB_URL .Values.variables.secret.DB_URL }}
+      initContainers:
+        - name: {{ .Chart.Name }}-prisma-migrate
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command: ["sh", "-c", "npx prisma migrate deploy; exit 0"]
+          {{- if .Values.variables.configmap.DB_URL }}
+          env:
+            - name: DATABASE_URL
+              value: {{ required ".Values.variables.configmap.DB_URL is required" .Values.variables.configmap.DB_URL }}
+          {{- else if .Values.variables.secret.DB_URL }}
+          env:
+            - name: DATABASE_URL
+              value: {{ required ".Values.variables.configmap.DB_URL is required" .Values.variables.configmap.DB_URL }}
+          {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:


### PR DESCRIPTION
It is desired that we run prisma migration on the datbase before accessing it via the generated service.