### PR TITLE
Opentelemetry plugin support for nestjs v10

### DIFF
--- a/plugins/observability-opentelemetry/package-lock.json
+++ b/plugins/observability-opentelemetry/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amplication/plugin-observability-opentelemetry",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amplication/plugin-observability-opentelemetry",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@amplication/code-gen-types": "^2.0.8",

--- a/plugins/observability-opentelemetry/package.json
+++ b/plugins/observability-opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/plugin-observability-opentelemetry",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "This plugin is created to add integrate opentelemetry to the amplication app",
   "main": "dist/index.js",
   "scripts": {

--- a/plugins/observability-opentelemetry/src/constants.ts
+++ b/plugins/observability-opentelemetry/src/constants.ts
@@ -12,7 +12,7 @@ export const placeholders = {
 
 export const packageJsonValues = {
   dependencies: {
-    "@amplication/opentelemetry-nestjs": "^4.3.7",
+    "@amplication/opentelemetry-nestjs": "^4.4.0",
   },
 };
 

--- a/plugins/observability-opentelemetry/src/events/createAppModule.ts
+++ b/plugins/observability-opentelemetry/src/events/createAppModule.ts
@@ -68,7 +68,7 @@ const generateImports = (): namedTypes.ImportDeclaration[] => {
       [OTLP_TRACE_EXPORTER],
       "@opentelemetry/exporter-trace-otlp-grpc"
     ),
-    importNames([BATCH_SPAN_PROCESSOR], "@opentelemetry/sdk-trace-base"),
+    importNames([BATCH_SPAN_PROCESSOR], "@opentelemetry/sdk-trace-node"),
   ];
 };
 

--- a/plugins/observability-opentelemetry/src/tests/__snapshots__/createApp.spec.ts.snap
+++ b/plugins/observability-opentelemetry/src/tests/__snapshots__/createApp.spec.ts.snap
@@ -12,7 +12,7 @@ exports[`Testing createApp hook should add the necessary imports 1`] = `
 
 import { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-grpc";
-import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";"
+import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-node";"
 `;
 
 exports[`Testing createApp hook should add the opentelemetry module to the modules list 1`] = `

--- a/plugins/observability-opentelemetry/src/tests/createDockerCompose.spec.ts
+++ b/plugins/observability-opentelemetry/src/tests/createDockerCompose.spec.ts
@@ -48,8 +48,8 @@ describe("Testing beforeCreateServerDockeCompose hook", () => {
               "13133:13133", // health check extension
               "55670:55679", // zpages debugging extension
             ],
-            volumes: ["./otel-config.yaml:/etc/otel-config.yaml"],
-            command: ["--config=/etc/otel-config.yaml"],
+            volumes: ["./otel-config.yml:/etc/otel-config.yml"],
+            command: ["--config=/etc/otel-config.yml"],
             depends_on: ["jaeger"],
           },
         },

--- a/plugins/observability-opentelemetry/src/tests/createDockerComposeDev.spec.ts
+++ b/plugins/observability-opentelemetry/src/tests/createDockerComposeDev.spec.ts
@@ -38,8 +38,8 @@ describe("Testing beforeCreateServerDockeCompose hook", () => {
               "13133:13133", // health check extension
               "55670:55679", // zpages debugging extension
             ],
-            volumes: ["./otel-config.yaml:/etc/otel-config.yaml"],
-            command: ["--config=/etc/otel-config.yaml"],
+            volumes: ["./otel-config.yml:/etc/otel-config.yml"],
+            command: ["--config=/etc/otel-config.yml"],
             depends_on: ["jaeger"],
           },
         },

--- a/plugins/observability-opentelemetry/src/tests/createPackageJson.spec.ts
+++ b/plugins/observability-opentelemetry/src/tests/createPackageJson.spec.ts
@@ -1,4 +1,7 @@
-import { CreateServerPackageJsonParams, DsgContext } from "@amplication/code-gen-types";
+import {
+  CreateServerPackageJsonParams,
+  DsgContext,
+} from "@amplication/code-gen-types";
 import { beforeCreateServerPackageJson } from "@/events/createPackageJson";
 import { mock } from "jest-mock-extended";
 
@@ -8,23 +11,28 @@ describe("Testing beforeServerPackageJson hook", () => {
 
   beforeEach(() => {
     context = mock<DsgContext>({
-      pluginInstallations: [{ npm: "@amplication/plugin-observability-opentelemetry" }],
+      pluginInstallations: [
+        { npm: "@amplication/plugin-observability-opentelemetry" },
+      ],
     });
     eventParams = {
       fileContent: "",
       updateProperties: [],
     };
-  }); 
+  });
 
   it("should add required dependencies to package.json", () => {
-    const { updateProperties } = beforeCreateServerPackageJson(context, eventParams);
+    const { updateProperties } = beforeCreateServerPackageJson(
+      context,
+      eventParams
+    );
 
     expect(updateProperties).toStrictEqual([
       {
         dependencies: {
-          "@amplication/opentelemetry-nestjs": "^4.3.7",
+          "@amplication/opentelemetry-nestjs": "^4.4.0",
         },
-      }
+      },
     ]);
   });
 });


### PR DESCRIPTION
Fixes: amplication/amplication#7317

## PR Details

This PR changes the generated code to have no type errors and fixes failing tests.
The PR amplication/opentelemetry-nestjs/pull/7 should also be merged to for this plugin to support nestjs v10.

Also, I don't think any tests are needed for the changes added.

## PR Checklist

- [x] `npm build` doesn't throw any error
- [x] `npm test` doesn't throw any error

