### PR TITLE
fix(aws-secrets-manager): Wrong format of secrets in the given example

### DIFF
--- a/plugins/secrets-manager-aws-secret-manager/README.md
+++ b/plugins/secrets-manager-aws-secret-manager/README.md
@@ -22,9 +22,10 @@ Example:
 ```json
 "fetchMode": "STARTUP",
 "secretNames": [
-    "/secretA",
-    "/path/path2/secretB",
-    "/path/path2/path3/secretC"
+    "/path/common",
+    "/path/path1:SecretA",
+    "/path/path2:SecretB",
+    "/path/path2/path3:SecretC"
 ]
 
 ```


### PR DESCRIPTION
## PR Details

In the given example for AWS Secrets Manager plugin, the format of the secrets is wrong.

Currently, it is:

```json
"fetchMode": "STARTUP",
"secretNames": [
    "/secretA",
    "/path/path2/secretB",
    "/path/path2/path3/secretC"
]
```
However, secret name should be separated from path with `:` (according to README). So rather, it should be smth like this:

```json
"fetchMode": "STARTUP",
"secretNames": [
    "/path/common",
    "/path/path1:SecretA",
    "/path/path2:SecretB",
    "/path/path2/path3:SecretC"
]

```

## PR Checklist

- [ ] Tests for the changes have been added
- [X] `npm build` doesn't throw any error
- [X] `npm test` doesn't throw any error

My bad, I didn't update the README with the new format :sweat_smile: 