### PR TITLE
fix(grpc): create json field as repeated string in protobuf file

### DIFF
--- a/plugins/transport-grpc/package-lock.json
+++ b/plugins/transport-grpc/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amplication/plugin-transport-grpc",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@amplication/plugin-transport-grpc",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@amplication/code-gen-utils": "^0.0.6",

--- a/plugins/transport-grpc/package.json
+++ b/plugins/transport-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/plugin-transport-grpc",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "add gRPC endpoints to your generated services",
   "main": "dist/index.js",
   "scripts": {

--- a/plugins/transport-grpc/src/core/create-grpc-proto-file.ts
+++ b/plugins/transport-grpc/src/core/create-grpc-proto-file.ts
@@ -339,7 +339,7 @@ export const createProtobufSchemaFieldsHandler: {
     fieldName: string,
     countField: number,
     field: EntityField
-  ) => createScalarField(fieldName, "json", countField, false),
+  ) => createScalarField(fieldName, "string", countField, true),
   [EnumDataType.Username]: (
     fieldName: string,
     countField: number,


### PR DESCRIPTION
Fixes: amplication/amplication#7412

## PR Details

Create protobuf field json as a repeated string. 
## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm build` doesn't throw any error
- [ ] `npm test` doesn't throw any error

