### PR TITLE
Fix/7549: add dynamic find function name for auth entity service

### DIFF
--- a/plugins/auth-core/package-lock.json
+++ b/plugins/auth-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amplication/plugin-auth-core",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@amplication/plugin-auth-core",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@amplication/code-gen-types": "^2.0.17",

--- a/plugins/auth-core/package.json
+++ b/plugins/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/plugin-auth-core",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "set auth for Amplication build",
   "main": "dist/index.js",
   "nx": {},

--- a/plugins/auth-core/src/core/create-auth-service-spec.ts
+++ b/plugins/auth-core/src/core/create-auth-service-spec.ts
@@ -13,18 +13,19 @@ import {
   removeTSClassDeclares,
 } from "../util/ast";
 import { builders, namedTypes } from "ast-types";
+import { camelCase } from "lodash";
 
 const authServiceSpecPath = join(
   templatesPath,
-  "auth.service.spec.template.ts"
+  "auth.service.spec.template.ts",
 );
 
 export async function createAuthServiceSpec(
-  dsgContext: DsgContext
+  dsgContext: DsgContext,
 ): Promise<Module> {
   const { entities, resourceInfo, serverDirectories } = dsgContext;
   const authEntity = entities?.find(
-    (x) => x.name === resourceInfo?.settings.authEntityName
+    (x) => x.name === resourceInfo?.settings.authEntityName,
   );
   if (!authEntity) {
     dsgContext.logger.error(AUTH_ENTITY_LOG_ERROR);
@@ -40,18 +41,19 @@ export async function createAuthServiceSpec(
 
   const entityServiceImport = importNames(
     [authServiceNameId],
-    `../${entityNameToLower}/${entityNameToLower}.service`
+    `../${entityNameToLower}/${entityNameToLower}.service`,
   );
 
   addImports(
     template,
     [entityServiceImport].filter(
-      (x) => x //remove nulls and undefined
-    ) as namedTypes.ImportDeclaration[]
+      (x) => x, //remove nulls and undefined
+    ) as namedTypes.ImportDeclaration[],
   );
 
   const templateMapping = {
     ENTITY_SERVICE: builders.identifier(entityServiceName),
+    FIND_ONE_FUNCTION: builders.identifier(`${camelCase(authEntity?.name)}`),
   };
 
   interpolate(template, templateMapping);

--- a/plugins/auth-core/src/templates/auth.service.spec.template.ts
+++ b/plugins/auth-core/src/templates/auth.service.spec.template.ts
@@ -32,7 +32,7 @@ const USER: any = {
 const SIGN_TOKEN = "SIGN_TOKEN";
 
 const authEntityService = {
-  findOne(args: { where: { username: string } }): any | null {
+  FIND_ONE_FUNCTION(args: { where: { username: string } }): any | null {
     if (args.where.username === VALID_CREDENTIALS.username) {
       return USER;
     }
@@ -86,8 +86,8 @@ describe("AuthService", () => {
       await expect(
         service.validateUser(
           VALID_CREDENTIALS.username,
-          VALID_CREDENTIALS.password
-        )
+          VALID_CREDENTIALS.password,
+        ),
       ).resolves.toEqual({
         username: USER.username,
         roles: USER.roles,
@@ -99,8 +99,8 @@ describe("AuthService", () => {
       await expect(
         service.validateUser(
           INVALID_CREDENTIALS.username,
-          INVALID_CREDENTIALS.password
-        )
+          INVALID_CREDENTIALS.password,
+        ),
       ).resolves.toBe(null);
     });
   });

--- a/plugins/auth-jwt/package-lock.json
+++ b/plugins/auth-jwt/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amplication/plugin-auth-jwt",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@amplication/plugin-auth-jwt",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "license": "ISC",
       "dependencies": {
         "@amplication/code-gen-types": "^2.0.19",

--- a/plugins/auth-jwt/package.json
+++ b/plugins/auth-jwt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/plugin-auth-jwt",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "set jwt as provider for Amplication build",
   "main": "dist/index.js",
   "nx": {},

--- a/plugins/auth-jwt/src/core/create-jwt-strategy-base.ts
+++ b/plugins/auth-jwt/src/core/create-jwt-strategy-base.ts
@@ -16,6 +16,7 @@ import {
 } from "../util/ast";
 import { builders, namedTypes } from "ast-types";
 import { print } from "@amplication/code-gen-utils";
+import { camelCase } from "lodash";
 
 const jwtStrategyBasePath = join(
   templatesPath,
@@ -76,6 +77,7 @@ async function mapJwtStrategyTemplate(
     const templateMapping = {
       ENTITY_NAME_INFO: builders.identifier(`${authEntity.name}Info`),
       ENTITY_SERVICE: builders.identifier(`${entityNameToLower}Service`),
+      FIND_ONE_FUNCTION: builders.identifier(`${camelCase(authEntity?.name) }`)
     };
 
     const filePath = `${serverDirectories.authDirectory}/jwt/base/${fileName}`;

--- a/plugins/auth-jwt/src/core/create-jwt-strategy-spec.ts
+++ b/plugins/auth-jwt/src/core/create-jwt-strategy-spec.ts
@@ -14,6 +14,7 @@ import {
 } from "../util/ast";
 import { builders, namedTypes } from "ast-types";
 import { print } from "@amplication/code-gen-utils";
+import { camelCase } from "lodash";
 
 const jwtStrategySpecPath = join(
   templatesPath,
@@ -65,6 +66,7 @@ async function mapJwtStrategySpecTemplate(
 
     const templateMapping = {
       ENTITY_SERVICE: builders.identifier(`${entityServiceName}`),
+      FIND_ONE_FUNCTION: builders.identifier(`${camelCase(authEntity?.name) }`)
     };
 
     const filePath = `${serverDirectories.srcDirectory}/tests/auth/jwt/${fileName}`;

--- a/plugins/auth-jwt/src/templates/jwt.strategy.template.base.ts
+++ b/plugins/auth-jwt/src/templates/jwt.strategy.template.base.ts
@@ -20,7 +20,7 @@ export class JwtStrategyBase
 
   async validate(payload: ENTITY_NAME_INFO): Promise<ENTITY_NAME_INFO> {
     const { username } = payload;
-    const user = await this.ENTITY_SERVICE.findOne({
+    const user = await this.ENTITY_SERVICE.FIND_ONE_FUNCTION({
       where: { username },
     });
     if (!user) {

--- a/plugins/auth-jwt/src/templates/jwt.strategy.template.spec.ts
+++ b/plugins/auth-jwt/src/templates/jwt.strategy.template.spec.ts
@@ -8,11 +8,11 @@ describe("Testing the jwtStrategyBase.validate()", () => {
   const userService = mock<ENTITY_SERVICE>();
   const jwtStrategy = new JwtStrategyBase("Secrete", userService);
   beforeEach(() => {
-    userService.findOne.mockClear();
+    userService.FIND_ONE_FUNCTION.mockClear();
   });
   it("should throw UnauthorizedException where there is no user", async () => {
     //ARRANGE
-    userService.findOne
+    userService.FIND_ONE_FUNCTION
       .calledWith({ where: { username: TEST_USER.username } })
       .mockReturnValue(Promise.resolve(null));
     //ACT


### PR DESCRIPTION
Fixes: amplication/amplication#7549

## PR Details

add dynamic find function name for auth entity service. 

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm build` doesn't throw any error
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
