### PR TITLE
fix(gRPC): dynamically mapping methods names

### DIFF
--- a/plugins/transport-grpc/package-lock.json
+++ b/plugins/transport-grpc/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amplication/plugin-transport-grpc",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@amplication/plugin-transport-grpc",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@amplication/code-gen-utils": "^0.0.6",

--- a/plugins/transport-grpc/package.json
+++ b/plugins/transport-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/plugin-transport-grpc",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "add gRPC endpoints to your generated services",
   "main": "dist/index.js",
   "nx": {},

--- a/plugins/transport-grpc/src/templates/controller.grpc.base.template.ts
+++ b/plugins/transport-grpc/src/templates/controller.grpc.base.template.ts
@@ -23,18 +23,27 @@ declare class ENTITY {}
 declare interface Select {}
 
 declare interface SERVICE {
-  create(args: { data: CREATE_INPUT; select: Select }): Promise<ENTITY>;
-  findMany(args: { where: WHERE_INPUT; select: Select }): Promise<ENTITY[]>;
-  findOne(args: {
+  CREATE_FUNCTION(args: {
+    data: CREATE_INPUT;
+    select: Select;
+  }): Promise<ENTITY>;
+  FIND_MANY_FUNCTION(args: {
+    where: WHERE_INPUT;
+    select: Select;
+  }): Promise<ENTITY[]>;
+  FIND_ONE_FUNCTION(args: {
     where: WHERE_UNIQUE_INPUT;
     select: Select;
   }): Promise<ENTITY | null>;
-  update(args: {
+  UPDATE_FUNCTION(args: {
     where: WHERE_UNIQUE_INPUT;
     data: UPDATE_INPUT;
     select: Select;
   }): Promise<ENTITY>;
-  delete(args: { where: WHERE_UNIQUE_INPUT; select: Select }): Promise<ENTITY>;
+  DELETE_FUNCTION(args: {
+    where: WHERE_UNIQUE_INPUT;
+    select: Select;
+  }): Promise<ENTITY>;
 }
 
 declare const RESOURCE: string;
@@ -48,9 +57,9 @@ export class CONTROLLER_GRPC_BASE {
   @common.Post()
   @swagger.ApiCreatedResponse({ type: ENTITY })
   async CREATE_ENTITY_FUNCTION(
-    @common.Body() data: CREATE_INPUT
+    @common.Body() data: CREATE_INPUT,
   ): Promise<ENTITY> {
-    return await this.service.create({
+    return await this.service.CREATE_FUNCTION({
       data: CREATE_DATA_MAPPING,
       select: SELECT,
     });
@@ -60,10 +69,10 @@ export class CONTROLLER_GRPC_BASE {
   @swagger.ApiOkResponse({ type: [ENTITY] })
   @ApiNestedQuery(FIND_MANY_ARGS)
   async FIND_MANY_ENTITY_FUNCTION(
-    @common.Req() request: Request
+    @common.Req() request: Request,
   ): Promise<ENTITY[]> {
     const args = plainToClass(FIND_MANY_ARGS, request.query);
-    return this.service.findMany({
+    return this.service.FIND_MANY_FUNCTION({
       ...args,
       select: SELECT,
     });
@@ -73,15 +82,15 @@ export class CONTROLLER_GRPC_BASE {
   @swagger.ApiOkResponse({ type: ENTITY })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   async FIND_ONE_ENTITY_FUNCTION(
-    @common.Param() params: WHERE_UNIQUE_INPUT
+    @common.Param() params: WHERE_UNIQUE_INPUT,
   ): Promise<ENTITY | null> {
-    const result = await this.service.findOne({
+    const result = await this.service.FIND_ONE_FUNCTION({
       where: params,
       select: SELECT,
     });
     if (result === null) {
       throw new errors.NotFoundException(
-        `No resource was found for ${JSON.stringify(params)}`
+        `No resource was found for ${JSON.stringify(params)}`,
       );
     }
     return result;
@@ -92,10 +101,10 @@ export class CONTROLLER_GRPC_BASE {
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   async UPDATE_ENTITY_FUNCTION(
     @common.Param() params: WHERE_UNIQUE_INPUT,
-    @common.Body() data: UPDATE_INPUT
+    @common.Body() data: UPDATE_INPUT,
   ): Promise<ENTITY | null> {
     try {
-      return await this.service.update({
+      return await this.service.UPDATE_FUNCTION({
         where: params,
         data: UPDATE_DATA_MAPPING,
         select: SELECT,
@@ -103,7 +112,7 @@ export class CONTROLLER_GRPC_BASE {
     } catch (error) {
       if (isRecordNotFoundError(error)) {
         throw new errors.NotFoundException(
-          `No resource was found for ${JSON.stringify(params)}`
+          `No resource was found for ${JSON.stringify(params)}`,
         );
       }
       throw error;
@@ -114,17 +123,17 @@ export class CONTROLLER_GRPC_BASE {
   @swagger.ApiOkResponse({ type: ENTITY })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   async DELETE_ENTITY_FUNCTION(
-    @common.Param() params: WHERE_UNIQUE_INPUT
+    @common.Param() params: WHERE_UNIQUE_INPUT,
   ): Promise<ENTITY | null> {
     try {
-      return await this.service.delete({
+      return await this.service.DELETE_FUNCTION({
         where: params,
         select: SELECT,
       });
     } catch (error) {
       if (isRecordNotFoundError(error)) {
         throw new errors.NotFoundException(
-          `No resource was found for ${JSON.stringify(params)}`
+          `No resource was found for ${JSON.stringify(params)}`,
         );
       }
       throw error;

--- a/plugins/transport-grpc/src/templates/to-many.grpc.template.ts
+++ b/plugins/transport-grpc/src/templates/to-many.grpc.template.ts
@@ -18,10 +18,10 @@ declare class RELATED_ENTITY_FIND_MANY_ARGS {}
 declare interface SERVICE {
   FIND_PROPERTY(
     parentId: string,
-    args: RELATED_ENTITY_WHERE_INPUT
+    args: RELATED_ENTITY_WHERE_INPUT,
   ): Promise<RELATED_ENTITY[]>;
 
-  update(args: {
+  UPDATE_FUNCTION(args: {
     where: WHERE_UNIQUE_INPUT;
     data: {
       PROPERTY: {
@@ -49,7 +49,7 @@ export class Mixin {
   @ApiNestedQuery(RELATED_ENTITY_FIND_MANY_ARGS)
   async FIND_MANY(
     @common.Req() request: Request,
-    @common.Param() params: WHERE_UNIQUE_INPUT
+    @common.Param() params: WHERE_UNIQUE_INPUT,
   ): Promise<RELATED_ENTITY[]> {
     const query = plainToClass(RELATED_ENTITY_FIND_MANY_ARGS, request.query);
     const results = await this.service.FIND_PROPERTY(params.id, {
@@ -58,7 +58,7 @@ export class Mixin {
     });
     if (results === null) {
       throw new errors.NotFoundException(
-        `No resource was found for ${JSON.stringify(params)}`
+        `No resource was found for ${JSON.stringify(params)}`,
       );
     }
     return results;
@@ -67,14 +67,14 @@ export class Mixin {
   @common.Post(CREATE_PATH)
   async CONNECT(
     @common.Param() params: WHERE_UNIQUE_INPUT,
-    @common.Body() body: RELATED_ENTITY_WHERE_UNIQUE_INPUT[]
+    @common.Body() body: RELATED_ENTITY_WHERE_UNIQUE_INPUT[],
   ): Promise<void> {
     const data = {
       PROPERTY: {
         connect: body,
       },
     };
-    await this.service.update({
+    await this.service.UPDATE_FUNCTION({
       where: params,
       data,
       select: { id: true },
@@ -84,14 +84,14 @@ export class Mixin {
   @common.Patch(UPDATE_PATH)
   async UPDATE(
     @common.Param() params: WHERE_UNIQUE_INPUT,
-    @common.Body() body: RELATED_ENTITY_WHERE_UNIQUE_INPUT[]
+    @common.Body() body: RELATED_ENTITY_WHERE_UNIQUE_INPUT[],
   ): Promise<void> {
     const data = {
       PROPERTY: {
         set: body,
       },
     };
-    await this.service.update({
+    await this.service.UPDATE_FUNCTION({
       where: params,
       data,
       select: { id: true },
@@ -101,14 +101,14 @@ export class Mixin {
   @common.Delete(DELETE_PATH)
   async DISCONNECT(
     @common.Param() params: WHERE_UNIQUE_INPUT,
-    @common.Body() body: RELATED_ENTITY_WHERE_UNIQUE_INPUT[]
+    @common.Body() body: RELATED_ENTITY_WHERE_UNIQUE_INPUT[],
   ): Promise<void> {
     const data = {
       PROPERTY: {
         disconnect: body,
       },
     };
-    await this.service.update({
+    await this.service.UPDATE_FUNCTION({
       where: params,
       data,
       select: { id: true },


### PR DESCRIPTION
Fixes: amplication/amplication#7795

## PR Details

dynamically mapping methods names.
## PR Checklist

- [ ] Tests for the changes have been added
- [x] `npm build` doesn't throw any error
- [x] `npm test` doesn't throw any error
