### PR TITLE
fix(auth-plugin): throw error on password field

### DIFF
--- a/plugins/auth-auth0/package-lock.json
+++ b/plugins/auth-auth0/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amplication/plugin-auth-auth0",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amplication/plugin-auth-auth0",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@amplication/code-gen-types": "^2.0.17",
@@ -1525,8 +1525,8 @@
       "dev": true
     },
     "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.5.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
@@ -3145,7 +3145,7 @@
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "reusify": "^1.0.4"
+        "reusify": "^1.0.5"
       }
     },
     "node_modules/fb-watchman": {
@@ -3308,7 +3308,7 @@
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
+        "inflight": "^1.0.5",
         "inherits": "2",
         "minimatch": "^3.1.1",
         "once": "^1.3.0",
@@ -5059,7 +5059,7 @@
       }
     },
     "node_modules/reusify": {
-      "version": "1.0.4",
+      "version": "1.0.5",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/plugins/auth-auth0/package-lock.json
+++ b/plugins/auth-auth0/package-lock.json
@@ -1525,8 +1525,8 @@
       "dev": true
     },
     "node_modules/@tsconfig/node16": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.5.tgz",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
@@ -3145,7 +3145,7 @@
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "reusify": "^1.0.5"
+        "reusify": "^1.0.4"
       }
     },
     "node_modules/fb-watchman": {
@@ -3308,7 +3308,7 @@
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.5",
+        "inflight": "^1.0.4",
         "inherits": "2",
         "minimatch": "^3.1.1",
         "once": "^1.3.0",
@@ -5059,7 +5059,7 @@
       }
     },
     "node_modules/reusify": {
-      "version": "1.0.5",
+      "version": "1.0.4",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/plugins/auth-auth0/package.json
+++ b/plugins/auth-auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/plugin-auth-auth0",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Auth0 plugin for Amplication",
   "main": "dist/index.js",
   "scripts": {

--- a/plugins/auth-auth0/src/utils/createAuthProperties.ts
+++ b/plugins/auth-auth0/src/utils/createAuthProperties.ts
@@ -21,7 +21,7 @@ export const NEW_DATE_EXPRESSION = builders.newExpression(DATE_ID, []);
 export const NEW_JSON_EXPRESSION = builders.objectExpression([
   builders.objectProperty(
     builders.stringLiteral("foo"),
-    builders.stringLiteral("bar")
+    builders.stringLiteral("bar"),
   ),
 ]);
 
@@ -32,7 +32,7 @@ export const DEFAULT_ROLE_LITERAL = builders.arrayExpression([
 
 export function createAuthEntityObjectCustomProperties(
   authEntity: Entity,
-  defaultValues: Record<string, unknown>
+  defaultValues: Record<string, unknown>,
 ): namedTypes.ObjectProperty[] {
   return authEntity.fields
     .filter((field) => field.required)
@@ -45,15 +45,15 @@ export function createAuthEntityObjectCustomProperties(
       builders.objectProperty(
         builders.identifier(field.name),
         // @ts-ignore
-        value
-      )
+        value,
+      ),
     );
 }
 
 export function createDefaultValue(
   field: EntityField,
   entity: Entity,
-  defaultValue: unknown
+  defaultValue: unknown,
 ): namedTypes.Expression | null {
   switch (field.dataType) {
     case EnumDataType.SingleLineText:
@@ -93,10 +93,10 @@ export function createDefaultValue(
       const [firstOption] = options;
       return defaultValue
         ? memberExpression`${createEnumName(field, entity)}.${pascalCase(
-            defaultValue as string
+            defaultValue as string,
           )}`
         : memberExpression`${createEnumName(field, entity)}.${pascalCase(
-            firstOption.label
+            firstOption.label,
           )}`;
     }
     case EnumDataType.Boolean: {
@@ -114,8 +114,7 @@ export function createDefaultValue(
     }
     case EnumDataType.Id:
     case EnumDataType.CreatedAt:
-    case EnumDataType.UpdatedAt:
-    case EnumDataType.Password: {
+    case EnumDataType.UpdatedAt: {
       return null;
     }
     case EnumDataType.Username: {
@@ -127,13 +126,17 @@ export function createDefaultValue(
       return defaultValue
         ? builders.arrayExpression(
             (defaultValue as string[]).map((item) =>
-              builders.stringLiteral(item)
-            )
+              builders.stringLiteral(item),
+            ),
           )
         : DEFAULT_ROLE_LITERAL;
     }
     case EnumDataType.Lookup: {
       return null;
+    }
+    case EnumDataType.Password: {
+      // Throw error on presence of password field in auth entity
+      throw new Error("Password field is not supported with Auth0 plugin");
     }
     default: {
       throw new Error(`Unexpected data type: ${field.dataType}`);

--- a/plugins/auth-keycloak/package-lock.json
+++ b/plugins/auth-keycloak/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amplication/plugin-auth-keycloak",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amplication/plugin-auth-keycloak",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@amplication/code-gen-types": "^2.0.19",

--- a/plugins/auth-keycloak/package.json
+++ b/plugins/auth-keycloak/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/plugin-auth-keycloak",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Keycloak Authentication plugin for Amplication",
   "main": "dist/index.js",
   "nx": {},

--- a/plugins/auth-keycloak/src/utils/createAuthProperties.ts
+++ b/plugins/auth-keycloak/src/utils/createAuthProperties.ts
@@ -115,8 +115,7 @@ export function createDefaultValue(
     }
     case EnumDataType.Id:
     case EnumDataType.CreatedAt:
-    case EnumDataType.UpdatedAt:
-    case EnumDataType.Password: {
+    case EnumDataType.UpdatedAt: {
       return null;
     }
     case EnumDataType.Username: {
@@ -135,6 +134,10 @@ export function createDefaultValue(
     }
     case EnumDataType.Lookup: {
       return null;
+    }
+    case EnumDataType.Password: {
+      // Throw error on presence of password field in auth entity
+      throw new Error("Password field is not supported with Keycloak plugin");
     }
     default: {
       throw new Error(`Unexpected data type: ${field.dataType}`);


### PR DESCRIPTION
Fixes: amplication/amplication#7044

## PR Details

- Throw error on presence of password field in auth-entity.

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm build` doesn't throw any error
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
