### PR TITLE
chore(ci): fix workflows affected changes calculation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,14 +38,22 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Get changed files
+        id: files
+        uses: tj-actions/changed-files@v42
+        with:
+          files_ignore: package-lock.json
+          base_sha: ${{ steps.setSHAs.outputs.base }}
+          separator: ","
+
       - name: Lint
-        run: npx nx affected --target=lint --parallel
+        run: npx nx affected --target=lint --parallel --files=${{ steps.files.outputs.all_changed_files }}
 
       - name: Build
-        run: npx nx affected --target=build --parallel
+        run: npx nx affected --target=build --parallel --files=${{ steps.files.outputs.all_changed_files }}
 
       - name: Test
-        run: npx nx affected --target=test --parallel
+        run: npx nx affected --target=test --parallel --files=${{ steps.files.outputs.all_changed_files }}
 
   nx:
     name: Nx

--- a/.github/workflows/nx.template.yaml
+++ b/.github/workflows/nx.template.yaml
@@ -49,8 +49,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Get changed files
+        id: files
+        uses: tj-actions/changed-files@v42
+        with:
+          files_ignore: package-lock.json
+          base_sha: ${{ steps.setSHAs.outputs.base }}
+          separator: ","
+
       - name: Evaluate affected projects
         id: calculate-affected
         run: |
-          echo affected-plugins=$(npx nx show projects --affected --with-target npm:publish --json) >> $GITHUB_OUTPUT
+          echo affected-plugins=$(npx nx show projects --affected --with-target npm:publish --json --files=${{ steps.files.outputs.all_changed_files }}) >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT | grep affected

--- a/.github/workflows/publish-on-comment.yaml
+++ b/.github/workflows/publish-on-comment.yaml
@@ -110,6 +110,9 @@ jobs:
       - name: Install dependencies and build 🔧
         run: npm ci
 
+      - name: Build
+        run: npx nx build ${{ matrix.affected-plugin }}
+
       - name: Publish version dry-run
         run: npm publish --access public --tag beta --dry-run
         working-directory: plugins/${{ matrix.affected-plugin }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12391,7 +12391,7 @@
     },
     "plugins/auth-saml": {
       "name": "@amplication/plugin-auth-saml",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@amplication/auth-core": "*",

--- a/plugins/auth-saml/package.json
+++ b/plugins/auth-saml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/plugin-auth-saml",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Description of your plugin",
   "main": "dist/index.js",
   "nx": {},

--- a/plugins/auth-saml/project.json
+++ b/plugins/auth-saml/project.json
@@ -1,6 +1,7 @@
 {
   "targets": {
     "install:clean": {},
-    "lint": {}
+    "lint": {},
+    "npm:publish": {}
   }
 }


### PR DESCRIPTION
Fixes: amplication/amplication#8192

## PR Details

Update automation to calculate affected packages using a manually generated list of changed files.
This will prevent Nx to consider all plugins as affected when one plugin package.json is updated (as it will change the root package-lock.json).

Temporary solution until Nx solve this https://github.com/nrwl/nx/issues/22259

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm build` doesn't throw any error
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
