### PR TITLE
chore(ci): fix issue related to wrong git ref was used for changed files calculations

### DIFF
--- a/.github/workflows/nx.template.yaml
+++ b/.github/workflows/nx.template.yaml
@@ -54,7 +54,7 @@ jobs:
         uses: tj-actions/changed-files@v42
         with:
           files_ignore: package-lock.json
-          base_sha: ${{ steps.setSHAs.outputs.base }}
+          base_sha: ${{ env.NX_BASE }}
           separator: ","
 
       - name: Evaluate affected projects


### PR DESCRIPTION
Fixes: https://github.com/amplication/amplication/issues/8233

## PR Details

Fix issue related to wrong git ref was used for changed files calculations.
The previous template was using `steps.setSHAs.outputs.base` but it was always evaluated as "undefined". Now it uses the env var setup by Nx set sha step as described here https://github.com/nrwl/nx-set-shas

i.e. https://github.com/amplication/plugins/actions/runs/8324867882/job/22777359713#step:6:60


## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm build` doesn't throw any error
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
