### PR TITLE
fix: seed script always changing on code generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5893,11 +5893,6 @@
         "node": "*"
       }
     },
-    "node_modules/crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
-    },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -12239,14 +12234,13 @@
     },
     "plugins/auth-auth0": {
       "name": "@amplication/plugin-auth-auth0",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@amplication/code-gen-types": "^2.0.23",
         "@amplication/code-gen-utils": "^0.0.9",
         "@types/node": "^20.11.24",
         "auth0": "^4.1.0",
-        "crypto-js": "^4.2.0",
         "lodash": "^4.17.21",
         "normalize-path": "^3.0.0"
       },
@@ -12366,13 +12360,12 @@
     },
     "plugins/auth-keycloak": {
       "name": "@amplication/plugin-auth-keycloak",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@amplication/code-gen-types": "^2.0.23",
         "@amplication/code-gen-utils": "^0.0.9",
         "@types/node": "^20.11.24",
-        "crypto-js": "^4.2.0",
         "js-convert-case": "^4.2.0",
         "lodash": "^4.17.21",
         "normalize-path": "^3.0.0"

--- a/plugins/auth-auth0/package.json
+++ b/plugins/auth-auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/plugin-auth-auth0",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Auth0 plugin for Amplication",
   "main": "dist/index.js",
   "scripts": {
@@ -15,9 +15,8 @@
   "dependencies": {
     "@amplication/code-gen-types": "^2.0.23",
     "@amplication/code-gen-utils": "^0.0.9",
-    "auth0": "^4.1.0",
-    "crypto-js": "^4.2.0",
     "@types/node": "^20.11.24",
+    "auth0": "^4.1.0",
     "lodash": "^4.17.21",
     "normalize-path": "^3.0.0"
   },

--- a/plugins/auth-auth0/src/utils/createAuthProperties.ts
+++ b/plugins/auth-auth0/src/utils/createAuthProperties.ts
@@ -22,7 +22,7 @@ export const NEW_DATE_EXPRESSION = builders.newExpression(DATE_ID, []);
 export const NEW_JSON_EXPRESSION = builders.objectExpression([
   builders.objectProperty(
     builders.stringLiteral("foo"),
-    builders.stringLiteral("bar"),
+    builders.stringLiteral("bar")
   ),
 ]);
 
@@ -31,13 +31,9 @@ export const DEFAULT_ROLE_LITERAL = builders.arrayExpression([
   builders.stringLiteral("user"),
 ]);
 
-export function generateRandomString(): string {
-  return crypto.randomBytes(10).toString("hex");
-}
-
 export function createAuthEntityObjectCustomProperties(
   authEntity: Entity,
-  defaultValues: Record<string, unknown>,
+  defaultValues: Record<string, unknown>
 ): namedTypes.ObjectProperty[] {
   return authEntity.fields
     .filter((field) => field.required)
@@ -50,15 +46,15 @@ export function createAuthEntityObjectCustomProperties(
       builders.objectProperty(
         builders.identifier(field.name),
         // @ts-ignore
-        value,
-      ),
+        value
+      )
     );
 }
 
 export function createDefaultValue(
   field: EntityField,
   entity: Entity,
-  defaultValue: unknown,
+  defaultValue: unknown
 ): namedTypes.Expression | null {
   switch (field.dataType) {
     case EnumDataType.SingleLineText:
@@ -98,10 +94,10 @@ export function createDefaultValue(
       const [firstOption] = options;
       return defaultValue
         ? memberExpression`${createEnumName(field, entity)}.${pascalCase(
-            defaultValue as string,
+            defaultValue as string
           )}`
         : memberExpression`${createEnumName(field, entity)}.${pascalCase(
-            firstOption.label,
+            firstOption.label
           )}`;
     }
     case EnumDataType.Boolean: {
@@ -122,7 +118,8 @@ export function createDefaultValue(
     case EnumDataType.UpdatedAt: {
       return null;
     }
-    case EnumDataType.Username: {
+    case EnumDataType.Username:
+    case EnumDataType.Password: {
       return defaultValue
         ? builders.stringLiteral(defaultValue as string)
         : DEFAULT_USERNAME_LITERAL;
@@ -131,18 +128,13 @@ export function createDefaultValue(
       return defaultValue
         ? builders.arrayExpression(
             (defaultValue as string[]).map((item) =>
-              builders.stringLiteral(item),
-            ),
+              builders.stringLiteral(item)
+            )
           )
         : DEFAULT_ROLE_LITERAL;
     }
     case EnumDataType.Lookup: {
       return null;
-    }
-    case EnumDataType.Password: {
-      return defaultValue
-        ? builders.stringLiteral(defaultValue as string)
-        : builders.stringLiteral(generateRandomString());
     }
     default: {
       throw new Error(`Unexpected data type: ${field.dataType}`);

--- a/plugins/auth-auth0/src/utils/createAuthProperties.ts
+++ b/plugins/auth-auth0/src/utils/createAuthProperties.ts
@@ -26,6 +26,7 @@ export const NEW_JSON_EXPRESSION = builders.objectExpression([
 ]);
 
 export const DEFAULT_USERNAME_LITERAL = builders.stringLiteral("admin");
+export const DEFAULT_PASSWORD_LITERAL = builders.stringLiteral("admin");
 export const DEFAULT_ROLE_LITERAL = builders.arrayExpression([
   builders.stringLiteral("user"),
 ]);
@@ -117,11 +118,15 @@ export function createDefaultValue(
     case EnumDataType.UpdatedAt: {
       return null;
     }
-    case EnumDataType.Username:
-    case EnumDataType.Password: {
+    case EnumDataType.Username: {
       return defaultValue
         ? builders.stringLiteral(defaultValue as string)
         : DEFAULT_USERNAME_LITERAL;
+    }
+    case EnumDataType.Password: {
+      return defaultValue
+        ? builders.stringLiteral(defaultValue as string)
+        : DEFAULT_PASSWORD_LITERAL;
     }
     case EnumDataType.Roles: {
       return defaultValue

--- a/plugins/auth-auth0/src/utils/createAuthProperties.ts
+++ b/plugins/auth-auth0/src/utils/createAuthProperties.ts
@@ -7,7 +7,6 @@ import {
 import { builders, namedTypes } from "ast-types";
 import { memberExpression } from "@utils/ast";
 import { createEnumName, pascalCase } from "@utils/helpers";
-import * as crypto from "crypto";
 
 const DEFAULT_ADDRESS = "(32.085300, 34.781769)";
 const DEFAULT_EMAIL = "example@example.com";

--- a/plugins/auth-keycloak/package.json
+++ b/plugins/auth-keycloak/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/plugin-auth-keycloak",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Keycloak Authentication plugin for Amplication",
   "main": "dist/index.js",
   "nx": {},
@@ -16,11 +16,10 @@
   "dependencies": {
     "@amplication/code-gen-types": "^2.0.23",
     "@amplication/code-gen-utils": "^0.0.9",
+    "@types/node": "^20.11.24",
     "js-convert-case": "^4.2.0",
     "lodash": "^4.17.21",
-    "normalize-path": "^3.0.0",
-    "crypto-js": "^4.2.0",
-    "@types/node": "^20.11.24"
+    "normalize-path": "^3.0.0"
   },
   "devDependencies": {
     "@babel/parser": "^7.23.3",

--- a/plugins/auth-keycloak/src/utils/createAuthProperties.ts
+++ b/plugins/auth-keycloak/src/utils/createAuthProperties.ts
@@ -23,7 +23,7 @@ export const NEW_DATE_EXPRESSION = builders.newExpression(DATE_ID, []);
 export const NEW_JSON_EXPRESSION = builders.objectExpression([
   builders.objectProperty(
     builders.stringLiteral("foo"),
-    builders.stringLiteral("bar"),
+    builders.stringLiteral("bar")
   ),
 ]);
 
@@ -32,13 +32,9 @@ export const DEFAULT_ROLE_LITERAL = builders.arrayExpression([
   builders.stringLiteral("user"),
 ]);
 
-export function generateRandomString(): string {
-  return crypto.randomBytes(10).toString("hex");
-}
-
 export function createAuthEntityObjectCustomProperties(
   authEntity: Entity,
-  defaultValues: Record<string, unknown>,
+  defaultValues: Record<string, unknown>
 ): namedTypes.ObjectProperty[] {
   return authEntity.fields
     .filter((field) => field.required)
@@ -51,15 +47,15 @@ export function createAuthEntityObjectCustomProperties(
       builders.objectProperty(
         builders.identifier(field.name),
         // @ts-expect-error: TODO: fix type
-        value,
-      ),
+        value
+      )
     );
 }
 
 export function createDefaultValue(
   field: EntityField,
   entity: Entity,
-  defaultValue: unknown,
+  defaultValue: unknown
 ): namedTypes.Expression | null {
   switch (field.dataType) {
     case EnumDataType.SingleLineText:
@@ -99,10 +95,10 @@ export function createDefaultValue(
       const [firstOption] = options;
       return defaultValue
         ? memberExpression`${createEnumName(field, entity)}.${toPascalCase(
-            defaultValue as string,
+            defaultValue as string
           )}`
         : memberExpression`${createEnumName(field, entity)}.${toPascalCase(
-            firstOption.label,
+            firstOption.label
           )}`;
     }
     case EnumDataType.Boolean: {
@@ -123,7 +119,8 @@ export function createDefaultValue(
     case EnumDataType.UpdatedAt: {
       return null;
     }
-    case EnumDataType.Username: {
+    case EnumDataType.Username:
+    case EnumDataType.Password: {
       return defaultValue
         ? builders.stringLiteral(defaultValue as string)
         : DEFAULT_USERNAME_LITERAL;
@@ -132,18 +129,13 @@ export function createDefaultValue(
       return defaultValue
         ? builders.arrayExpression(
             (defaultValue as string[]).map((item) =>
-              builders.stringLiteral(item),
-            ),
+              builders.stringLiteral(item)
+            )
           )
         : DEFAULT_ROLE_LITERAL;
     }
     case EnumDataType.Lookup: {
       return null;
-    }
-    case EnumDataType.Password: {
-      return defaultValue
-        ? builders.stringLiteral(defaultValue as string)
-        : builders.stringLiteral(generateRandomString());
     }
     default: {
       throw new Error(`Unexpected data type: ${field.dataType}`);

--- a/plugins/auth-keycloak/src/utils/createAuthProperties.ts
+++ b/plugins/auth-keycloak/src/utils/createAuthProperties.ts
@@ -8,7 +8,6 @@ import { builders, namedTypes } from "ast-types";
 import { memberExpression } from "./ast";
 import { createEnumName } from "./helpers";
 import { toPascalCase } from "js-convert-case";
-import * as crypto from "crypto";
 
 const DEFAULT_ADDRESS = "(32.085300, 34.781769)";
 const DEFAULT_EMAIL = "example@example.com";

--- a/plugins/auth-keycloak/src/utils/createAuthProperties.ts
+++ b/plugins/auth-keycloak/src/utils/createAuthProperties.ts
@@ -27,6 +27,7 @@ export const NEW_JSON_EXPRESSION = builders.objectExpression([
 ]);
 
 export const DEFAULT_USERNAME_LITERAL = builders.stringLiteral("admin");
+export const DEFAULT_PASSWORD_LITERAL = builders.stringLiteral("admin");
 export const DEFAULT_ROLE_LITERAL = builders.arrayExpression([
   builders.stringLiteral("user"),
 ]);
@@ -118,11 +119,15 @@ export function createDefaultValue(
     case EnumDataType.UpdatedAt: {
       return null;
     }
-    case EnumDataType.Username:
-    case EnumDataType.Password: {
+    case EnumDataType.Username: {
       return defaultValue
         ? builders.stringLiteral(defaultValue as string)
         : DEFAULT_USERNAME_LITERAL;
+    }
+    case EnumDataType.Password: {
+      return defaultValue
+        ? builders.stringLiteral(defaultValue as string)
+        : DEFAULT_PASSWORD_LITERAL;
     }
     case EnumDataType.Roles: {
       return defaultValue


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:
1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).
2. You are giving a descriptive title to your PR following CONTRIBUTING.md conventions
3. You are providing enough information about your changes for others to review your pull request.

-->

Fixes: amplication/amplication#8252

## PR Details

Fix password value for seed script in auth0 and keycloak plugins to avoid random creation of the same on every code generation. 
username and passwork used in the seed script are not used as part of the authentication and only to pre-seed the user table with an entry that will be used in the mapping on user authentication through the provider

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm build` doesn't throw any error
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
