### PR TITLE
Fix(broker-kafka): create an empty enum topic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13118,7 +13118,7 @@
     },
     "plugins/broker-kafka": {
       "name": "@amplication/plugin-broker-kafka",
-      "version": "2.0.12",
+      "version": "2.0.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@amplication/code-gen-types": "^2.0.23",

--- a/plugins/broker-kafka/package.json
+++ b/plugins/broker-kafka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/plugin-broker-kafka",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "Use a Kafka message broker to communicate between services generated with Amplication",
   "main": "dist/index.js",
   "nx": {},

--- a/plugins/broker-kafka/src/core/create-empty-enum-topics-file.ts
+++ b/plugins/broker-kafka/src/core/create-empty-enum-topics-file.ts
@@ -1,0 +1,33 @@
+import { DsgContext, Module, ModuleMap } from "@amplication/code-gen-types";
+import { getMessageBrokerName } from "./get-message-broker-name";
+import { builders } from "ast-types";
+import { EnumBuilder, print } from "@amplication/code-gen-utils";
+import { pascalCase } from "pascal-case";
+import { join } from "path";
+
+export async function createEmptyEnumTopicsFile(
+  context: DsgContext
+): Promise<ModuleMap> {
+  const messageBrokerName = getMessageBrokerName(context);
+
+  const enumTopicsFile = builders.file(builders.program([]));
+  const enumBuilder = new EnumBuilder(pascalCase(messageBrokerName) + "Topics");
+
+  const enumExportDeclaration = builders.exportDeclaration(
+    false,
+    enumBuilder.ast
+  );
+  enumTopicsFile.program.body.push(enumExportDeclaration);
+
+  const path = join(
+    context.serverDirectories.messageBrokerDirectory,
+    "topics.ts"
+  );
+  const module: Module = {
+    path,
+    code: print(enumTopicsFile).code,
+  };
+  const moduleMap = new ModuleMap(context.logger);
+  await moduleMap.set(module);
+  return moduleMap;
+}

--- a/plugins/broker-kafka/src/core/get-message-broker-name.ts
+++ b/plugins/broker-kafka/src/core/get-message-broker-name.ts
@@ -1,0 +1,19 @@
+import { DsgContext } from "@amplication/code-gen-types";
+import { EnumResourceType } from "@amplication/code-gen-types/src/models";
+
+export function getMessageBrokerName(context: DsgContext): string {
+  const { otherResources, logger } = context;
+  let messageBrokerName =
+    otherResources?.find(
+      (resource) => resource.resourceType === EnumResourceType.MessageBroker
+    )?.resourceInfo?.name ?? null;
+
+  if (!messageBrokerName) {
+    logger.warn(
+      "Message broker name not found. Did you forget to add a message broker resource?"
+    );
+    messageBrokerName = "kafka";
+  }
+
+  return messageBrokerName;
+}

--- a/plugins/broker-kafka/src/core/index.ts
+++ b/plugins/broker-kafka/src/core/index.ts
@@ -1,0 +1,2 @@
+export { getMessageBrokerName } from "./get-message-broker-name";
+export { createEmptyEnumTopicsFile } from "./create-empty-enum-topics-file";

--- a/plugins/broker-kafka/src/index.ts
+++ b/plugins/broker-kafka/src/index.ts
@@ -5,6 +5,7 @@ import {
   CreateMessageBrokerNestJSModuleParams,
   CreateMessageBrokerParams,
   CreateMessageBrokerServiceParams,
+  CreateMessageBrokerTopicsEnumParams,
   CreateServerAppModuleParams,
   CreateServerAuthParams,
   CreateServerDockerComposeDevParams,
@@ -35,7 +36,7 @@ import {
   interpolate,
 } from "./util/ast";
 import { pascalCase } from "pascal-case";
-import { EnumResourceType } from "@amplication/code-gen-types/src/models";
+import { createEmptyEnumTopicsFile, getMessageBrokerName } from "./core";
 
 class KafkaPlugin implements AmplicationPlugin {
   static moduleFile: Module | undefined;
@@ -76,12 +77,15 @@ class KafkaPlugin implements AmplicationPlugin {
       CreateConnectMicroservices: {
         before: this.beforeCreateConnectMicroservices,
       },
+      CreateMessageBrokerTopicsEnum: {
+        after: this.afterCreateMessageBrokerTopicsEnum,
+      },
     };
   }
 
   async afterCreateMessageBrokerClientOptionsFactory(
     context: DsgContext,
-    eventParams: CreateMessageBrokerClientOptionsFactoryParams,
+    eventParams: CreateMessageBrokerClientOptionsFactoryParams
   ): Promise<ModuleMap> {
     const { serverDirectories } = context;
     const filePath = resolve(staticDirectory, "generateKafkaClientOptions.ts");
@@ -90,7 +94,7 @@ class KafkaPlugin implements AmplicationPlugin {
 
     const path = join(
       serverDirectories.messageBrokerDirectory,
-      generateFileName,
+      generateFileName
     );
     const modules = new ModuleMap(context.logger);
     await modules.set({ code: print(file).code, path });
@@ -99,18 +103,18 @@ class KafkaPlugin implements AmplicationPlugin {
 
   beforeCreateBroker(
     dsgContext: DsgContext,
-    eventParams: CreateMessageBrokerParams,
+    eventParams: CreateMessageBrokerParams
   ): CreateMessageBrokerParams {
     dsgContext.serverDirectories.messageBrokerDirectory = join(
       dsgContext.serverDirectories.srcDirectory,
-      "kafka",
+      "kafka"
     );
     return eventParams;
   }
 
   async afterCreateMessageBrokerNestJSModule(
     context: DsgContext,
-    eventParams: CreateMessageBrokerNestJSModuleParams,
+    eventParams: CreateMessageBrokerNestJSModuleParams
   ): Promise<ModuleMap> {
     const filePath = resolve(staticDirectory, "kafka.module.ts");
 
@@ -131,7 +135,7 @@ class KafkaPlugin implements AmplicationPlugin {
 
   beforeCreateServerDotEnv(
     context: DsgContext,
-    eventParams: CreateServerDotEnvParams,
+    eventParams: CreateServerDotEnvParams
   ): CreateServerDotEnvParams {
     const resourceName = context.resourceInfo?.name;
 
@@ -150,7 +154,7 @@ class KafkaPlugin implements AmplicationPlugin {
 
   beforeCreateServerPackageJson(
     context: DsgContext,
-    eventParams: CreateServerPackageJsonParams,
+    eventParams: CreateServerPackageJsonParams
   ): CreateServerPackageJsonParams {
     const myValues = {
       dependencies: {
@@ -166,36 +170,26 @@ class KafkaPlugin implements AmplicationPlugin {
 
   async afterCreateMessageBrokerService(
     context: DsgContext,
-    eventParams: CreateMessageBrokerServiceParams,
+    eventParams: CreateMessageBrokerServiceParams
   ): Promise<ModuleMap> {
-    const { serverDirectories, logger, otherResources } = context;
+    const { serverDirectories, logger } = context;
     const { messageBrokerDirectory } = serverDirectories;
 
     const servicePath = join(
       messageBrokerDirectory,
-      `kafka.producer.service.ts`,
+      `kafka.producer.service.ts`
     );
 
-    let messageBrokerName =
-      otherResources?.find(
-        (resource) => resource.resourceType === EnumResourceType.MessageBroker,
-      )?.resourceInfo?.name ?? null;
-
-    if (!messageBrokerName) {
-      logger.warn(
-        "Message broker name not found. Did you forget to add a message broker resource?",
-      );
-      messageBrokerName = "kafka";
-    }
+    const messageBrokerName = getMessageBrokerName(context);
 
     const templatePath = join(
       templatesPath,
-      "kafka.producer.service.template.ts",
+      "kafka.producer.service.template.ts"
     );
     const template = await readFile(templatePath);
     const templateMapping = {
       BROKER_TOPICS: builders.identifier(
-        pascalCase(messageBrokerName) + "Topics",
+        pascalCase(messageBrokerName) + "Topics"
       ),
     };
 
@@ -203,19 +197,19 @@ class KafkaPlugin implements AmplicationPlugin {
 
     const kafkaMessageFilePath = resolve(
       `${staticDirectory}/contracts`,
-      `KafkaMessage.ts`,
+      `KafkaMessage.ts`
     );
     const kafkaMessageFile = await readFile(kafkaMessageFilePath);
     const kafkaMessagePath = join(messageBrokerDirectory, `KafkaMessage.ts`);
 
     const kafkaMessageHeaderFilePath = resolve(
       `${staticDirectory}/contracts`,
-      `KafkaMessageHeaders.ts`,
+      `KafkaMessageHeaders.ts`
     );
     const kafkaMessageHeaderFile = await readFile(kafkaMessageHeaderFilePath);
     const kafkaMessageHeaderPath = join(
       messageBrokerDirectory,
-      `KafkaMessageHeaders.ts`,
+      `KafkaMessageHeaders.ts`
     );
 
     const modules = new ModuleMap(logger);
@@ -234,7 +228,7 @@ class KafkaPlugin implements AmplicationPlugin {
 
   beforeCreateDockerComposeFile(
     dsgContext: DsgContext,
-    eventParams: CreateServerDockerComposeDevParams,
+    eventParams: CreateServerDockerComposeDevParams
   ): CreateServerDockerComposeDevParams {
     const updateDockerComposeProperties = {
       services: {
@@ -264,7 +258,7 @@ class KafkaPlugin implements AmplicationPlugin {
 
   beforeCreateDockerComposeDevFile(
     dsgContext: DsgContext,
-    eventParams: CreateServerDockerComposeDevParams,
+    eventParams: CreateServerDockerComposeDevParams
   ): CreateServerDockerComposeDevParams {
     eventParams.updateProperties.push(updateDockerComposeDevProperties);
     return eventParams;
@@ -272,7 +266,7 @@ class KafkaPlugin implements AmplicationPlugin {
 
   beforeCreateServerAppModule(
     dsgContext: DsgContext,
-    eventParams: CreateServerAppModuleParams,
+    eventParams: CreateServerAppModuleParams
   ) {
     const file = KafkaPlugin.moduleFile;
     if (!file) {
@@ -294,7 +288,7 @@ class KafkaPlugin implements AmplicationPlugin {
   async afterCreateServerAuth(
     context: DsgContext,
     eventParams: CreateServerAuthParams,
-    modules: ModuleMap,
+    modules: ModuleMap
   ): Promise<ModuleMap> {
     const templatePath = join(templatesPath, "controller.template.ts");
     const template = await readFile(templatePath);
@@ -318,19 +312,19 @@ class KafkaPlugin implements AmplicationPlugin {
         const eventPatternDecorator = builders.decorator(
           builders.callExpression(builders.identifier("EventPattern"), [
             builders.stringLiteral(topic.topicName),
-          ]),
+          ])
         );
 
         const payloadDecorator = builders.decorator(
-          builders.callExpression(builders.identifier("Payload"), []),
+          builders.callExpression(builders.identifier("Payload"), [])
         );
 
         const kafkaValue = builders.identifier.from({
           name: "value",
           typeAnnotation: builders.tsTypeAnnotation(
             builders.tsTypeReference(
-              builders.identifier("string | Record<string, any> | null"),
-            ),
+              builders.identifier("string | Record<string, any> | null")
+            )
           ),
         });
 
@@ -338,12 +332,12 @@ class KafkaPlugin implements AmplicationPlugin {
         kafkaValue.decorators = [payloadDecorator];
 
         const kafkaContextDecorator = builders.decorator(
-          builders.callExpression(builders.identifier("Ctx"), []),
+          builders.callExpression(builders.identifier("Ctx"), [])
         );
         const kafkaContext = builders.identifier.from({
           name: "context",
           typeAnnotation: builders.tsTypeAnnotation(
-            builders.tsTypeReference(builders.identifier("KafkaContext")),
+            builders.tsTypeReference(builders.identifier("KafkaContext"))
           ),
         });
 
@@ -358,10 +352,10 @@ class KafkaPlugin implements AmplicationPlugin {
                 builders.callExpression(
                   builders.memberExpression(
                     builders.identifier("context"),
-                    builders.identifier("getMessage"),
+                    builders.identifier("getMessage")
                   ),
-                  [],
-                ),
+                  []
+                )
               ),
             ]),
           ]),
@@ -371,8 +365,8 @@ class KafkaPlugin implements AmplicationPlugin {
           returnType: builders.tsTypeAnnotation(
             builders.tsTypeReference(
               builders.identifier("Promise"),
-              builders.tsTypeParameterInstantiation([builders.tsVoidKeyword()]),
-            ),
+              builders.tsTypeParameterInstantiation([builders.tsVoidKeyword()])
+            )
           ),
           decorators: [eventPatternDecorator],
         });
@@ -383,7 +377,7 @@ class KafkaPlugin implements AmplicationPlugin {
     const filePath = join(
       serverDirectories.srcDirectory,
       "kafka",
-      "kafka.controller.ts",
+      "kafka.controller.ts"
     );
 
     const controllerFile = { code: print(template).code, path: filePath };
@@ -394,25 +388,25 @@ class KafkaPlugin implements AmplicationPlugin {
 
   beforeCreateConnectMicroservices(
     context: DsgContext,
-    eventParams: CreateConnectMicroservicesParams,
+    eventParams: CreateConnectMicroservicesParams
   ): CreateConnectMicroservicesParams {
     const { template } = eventParams;
 
     const generateKafkaClientOptionsImport = importNames(
       [builders.identifier("generateKafkaClientOptions")],
-      "./kafka/generateKafkaClientOptions",
+      "./kafka/generateKafkaClientOptions"
     );
 
     const MicroserviceOptionsImport = importNames(
       [builders.identifier("MicroserviceOptions")],
-      "@nestjs/microservices",
+      "@nestjs/microservices"
     );
 
     addImports(
       template,
       [generateKafkaClientOptionsImport, MicroserviceOptionsImport].filter(
-        (x) => x, //remove nulls and undefined
-      ) as namedTypes.ImportDeclaration[],
+        (x) => x //remove nulls and undefined
+      ) as namedTypes.ImportDeclaration[]
     );
 
     const typeArguments = builders.tsTypeParameterInstantiation([
@@ -422,14 +416,14 @@ class KafkaPlugin implements AmplicationPlugin {
     const appExpression = builders.callExpression(
       builders.memberExpression(
         builders.identifier("app"),
-        builders.identifier("connectMicroservice"),
+        builders.identifier("connectMicroservice")
       ),
       [
         builders.callExpression(
           builders.identifier("generateKafkaClientOptions"),
-          [builders.identifier("configService")],
+          [builders.identifier("configService")]
         ),
-      ],
+      ]
     );
 
     appExpression.typeArguments =
@@ -439,12 +433,26 @@ class KafkaPlugin implements AmplicationPlugin {
 
     const functionDeclaration = getFunctionDeclarationById(
       template,
-      builders.identifier("connectMicroservices"),
+      builders.identifier("connectMicroservices")
     );
 
     functionDeclaration.body.body.push(kafkaServiceExpression);
 
     return eventParams;
+  }
+
+  async afterCreateMessageBrokerTopicsEnum(
+    context: DsgContext,
+    eventParams: CreateMessageBrokerTopicsEnumParams,
+    modules: ModuleMap
+  ): Promise<ModuleMap> {
+    const [enumTopicsModule] = modules.modules();
+    if (enumTopicsModule) return modules;
+    context.logger.warn(
+      `A message broker plugin is installed but not properly configured. Create a message broker resource,
+       add a topic, and connect the service as a sender or receiver to utilize the plugin.`
+    );
+    return await createEmptyEnumTopicsFile(context);
   }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/amplication/private-issues/issues/211

## PR Details

Create an empty enum topic in case no topics found. 
## PR Checklist

- [] Tests for the changes have been added
- [x] `npm build` doesn't throw any error
- [x] `npm test` doesn't throw any error

